### PR TITLE
`relational.write`: changes in upsert and delete statements  #211

### DIFF
--- a/integration-tests/common/pg.py
+++ b/integration-tests/common/pg.py
@@ -32,6 +32,7 @@ def create_emp_table(engine: Engine, schema_name: str):
         Column("id", Integer, primary_key=True, nullable=False),
         Column("full_name", String(50)),
         Column("country", String(50)),
+        Column("address", String(50)),
         Column("gender", String(1))
     ]
     Table("emp", base.metadata, *columns, schema=schema_name)

--- a/integration-tests/resources/jobs/tests/redis_to_pg.yaml
+++ b/integration-tests/resources/jobs/tests/redis_to_pg.yaml
@@ -26,10 +26,9 @@ steps:
       schema: hr
       table: emp
       opcode_field: __$$opcode
-      mapping:
+      keys:
         - id: _id
+      mapping:
         - full_name
         - country
         - gender
-      keys:
-        - id: _id

--- a/integration-tests/test_redis_to_pg.py
+++ b/integration-tests/test_redis_to_pg.py
@@ -38,9 +38,10 @@ def test_redis_to_pg():
 
     engine = pg.get_engine(postgres_container)
     pg.create_emp_table(engine, "hr")
-    engine.execute("INSERT INTO hr.emp VALUES (1, 'John Doe', '972 - ISRAEL', 'M')")
-    engine.execute("INSERT INTO hr.emp VALUES (10, 'john doe', '972 - ISRAEL', 'M')")
-    engine.execute("INSERT INTO hr.emp VALUES (12, 'steve steve', '972 - ISRAEL', 'M')")
+    engine.execute("INSERT INTO hr.emp (id, full_name, country, gender) VALUES (1, 'John Doe', '972 - ISRAEL', 'M')")
+    engine.execute("INSERT INTO hr.emp (id, full_name, country, gender) VALUES (10, 'john doe', '972 - ISRAEL', 'M')")
+    engine.execute(
+        "INSERT INTO hr.emp (id, full_name, country, gender, address) VALUES (12, 'steve steve', '972 - ISRAEL', 'M', 'main street')")
 
     run_job("tests.redis_to_pg")
 
@@ -61,6 +62,8 @@ def test_redis_to_pg():
     assert second_employee["full_name"] == "John Doe"
     assert second_employee["country"] == "972 - ISRAEL"
     assert second_employee["gender"] == "M"
+    assert second_employee["address"] == "main street"
+
 
     redis_container.stop()
     postgres_container.stop()


### PR DESCRIPTION
- UPSERT - only fields listed in mapping should get updated 
- business keys are now added to mapping
- do not use `sa.text` on delete